### PR TITLE
ffmpeg improvements: webm quality, and additional video formats

### DIFF
--- a/animatediff/model_utils.py
+++ b/animatediff/model_utils.py
@@ -11,6 +11,12 @@ folder_paths.folder_names_and_paths["AnimateDiff"] = (
     ],
     folder_paths.supported_pt_extensions,
 )
+folder_paths.folder_names_and_paths["video_formats"] = (
+    [
+        os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "video_formats"),
+    ],
+    [".json"]
+)
 
 
 def get_available_models():

--- a/video_formats/av1-webm.json
+++ b/video_formats/av1-webm.json
@@ -1,0 +1,10 @@
+{
+    "main_pass":
+    [
+        "-n", "-c:v", "libsvtav1",
+        "-pix_fmt", "yuv420p10le",
+        "-crf", "23"
+    ],
+     "extension": "webm",
+     "environment": {"SVT_LOG": "1"}
+}

--- a/video_formats/h264-mp4.json
+++ b/video_formats/h264-mp4.json
@@ -1,0 +1,9 @@
+{
+    "main_pass":
+    [
+        "-n", "-c:v", "libx264",
+        "-pix_fmt", "yuv420p",
+        "-crf", "19"
+    ],
+     "extension": "mp4"
+}

--- a/video_formats/h265-mp4.json
+++ b/video_formats/h265-mp4.json
@@ -1,0 +1,11 @@
+{
+    "main_pass":
+    [
+        "-n", "-c:v", "libx265",
+        "-pix_fmt", "yuv420p10le",
+        "-preset", "medium",
+        "-crf", "22",
+        "-x265-params", "log-level=quiet"
+    ],
+     "extension": "mp4"
+}

--- a/video_formats/webm.json
+++ b/video_formats/webm.json
@@ -1,0 +1,9 @@
+{
+    "main_pass":
+    [
+        "-n",
+        "-pix_fmt", "yuv420p",
+        "-crf", "23"
+    ],
+     "extension": "webm"
+}


### PR DESCRIPTION
Thank you for taking the time to implement the ffmpeg and animated preview functionality.

This pull request ports the ffmpeg format configuration code I wrote to work with how the ffmpeg changes were integrated here. It improves the quality of (vp9) webm outputs, adds support for additional codecs (h264, h265, av1), and allows end users to add additional output formats in a way that doesn't conflict with future updates.

While support for generating h265 mp4s is included, most browsers will be unable to display the resulting video which breaks the preview.